### PR TITLE
fix: env unrecognized option: S in dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG NODE_VERSION=20
 FROM node:${NODE_VERSION}-alpine
 
-RUN apk add --no-cache git \
+RUN apk add --no-cache git coreutils \
     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz \
     && cd /quartz \
     && mkdir -p content \


### PR DESCRIPTION
This PR fix a CI error when upstream file using a unsupport option `-S`, via: https://github.com/jackyzha0/quartz/blob/a201105442c3603a34cb609b70cef71072e71392/quartz/bootstrap-cli.mjs#L1

## Works

I've test on my notes(https://github.com/bGZo/notes/blob/3e09645fd998523be526bb1e40ecd812afcb28c0/.github/workflows/quartz.yml#L25), It works well.

## Solution

This chanage make environment using `env` of `coreutils` rather then `BusyBox` build-in, which  would meet following error: `/usr/bin/env: unrecognized option: S`

## Bug log

Full error log is following:

```log
2025-03-08T03:48:03.6430546Z Current runner version: '2.322.0'
2025-03-08T03:48:03.6455107Z ##[group]Operating System
2025-03-08T03:48:03.6455878Z Ubuntu
2025-03-08T03:48:03.6456312Z 24.04.2
2025-03-08T03:48:03.6456902Z LTS
2025-03-08T03:48:03.6457331Z ##[endgroup]
2025-03-08T03:48:03.6457817Z ##[group]Runner Image
2025-03-08T03:48:03.6458470Z Image: ubuntu-24.04
2025-03-08T03:48:03.6458955Z Version: 20250302.1.0
2025-03-08T03:48:03.6459949Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250302.1/images/ubuntu/Ubuntu2404-Readme.md
2025-03-08T03:48:03.6461369Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250302.1
2025-03-08T03:48:03.6462274Z ##[endgroup]
2025-03-08T03:48:03.6462763Z ##[group]Runner Image Provisioner
2025-03-08T03:48:03.6463608Z 2.0.422.1
2025-03-08T03:48:03.6464064Z ##[endgroup]
2025-03-08T03:48:03.6465052Z ##[group]GITHUB_TOKEN Permissions
2025-03-08T03:48:03.6466906Z Contents: read
2025-03-08T03:48:03.6467447Z Metadata: read
2025-03-08T03:48:03.6468187Z Pages: write
2025-03-08T03:48:03.6468727Z ##[endgroup]
2025-03-08T03:48:03.6470734Z Secret source: Actions
2025-03-08T03:48:03.6471440Z Prepare workflow directory
2025-03-08T03:48:03.6797158Z Prepare all required actions
2025-03-08T03:48:03.6852822Z Getting action download info
2025-03-08T03:48:04.2533300Z Download action repository 'actions/checkout@v4' (SHA:11bd71901bbe5b1630ceea73d27597364c9af683)
2025-03-08T03:48:04.3339117Z Download action repository 'actions/configure-pages@v5' (SHA:983d7736d9b0ae728b81ab479565c72886d7745b)
2025-03-08T03:48:04.8019089Z Download action repository 'konstfish/quartz-build-action@v3' (SHA:fdbcec61c90485c2aec7be1905f87f55f2928a18)
2025-03-08T03:48:05.2245021Z Download action repository 'actions/upload-pages-artifact@v3' (SHA:56afc609e74202658d3ffba0e8f6dda462b719fa)
2025-03-08T03:48:05.5808546Z Download action repository 'actions/upload-artifact@v4' (SHA:4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1)
2025-03-08T03:48:05.7736236Z Getting action download info
2025-03-08T03:48:05.9335146Z Complete job name: build
2025-03-08T03:48:05.9790271Z ##[group]Build container for action use: '/home/runner/work/_actions/konstfish/quartz-build-action/v3/Dockerfile'.
2025-03-08T03:48:05.9844300Z ##[command]/usr/bin/docker build -t d9a3de:d252db9bf8784d7ca5d369bb083c9f7a -f "/home/runner/work/_actions/konstfish/quartz-build-action/v3/Dockerfile" "/home/runner/work/_actions/konstfish/quartz-build-action/v3"
2025-03-08T03:48:06.3773029Z #0 building with "default" instance using docker driver
2025-03-08T03:48:06.3773480Z 
2025-03-08T03:48:06.3773650Z #1 [internal] load build definition from Dockerfile
2025-03-08T03:48:06.3774057Z #1 transferring dockerfile: 404B done
2025-03-08T03:48:06.3774383Z #1 DONE 0.0s
2025-03-08T03:48:06.3774538Z 
2025-03-08T03:48:06.3774740Z #2 [internal] load metadata for docker.io/library/node:20-alpine
2025-03-08T03:48:06.6205836Z #2 ...
2025-03-08T03:48:06.6206080Z 
2025-03-08T03:48:06.6206298Z #3 [auth] library/node:pull token for registry-1.docker.io
2025-03-08T03:48:06.6206745Z #3 DONE 0.0s
2025-03-08T03:48:06.7707222Z 
2025-03-08T03:48:06.7707632Z #2 [internal] load metadata for docker.io/library/node:20-alpine
2025-03-08T03:48:07.2367515Z #2 DONE 1.0s
2025-03-08T03:48:07.3573488Z 
2025-03-08T03:48:07.3573849Z #4 [internal] load .dockerignore
2025-03-08T03:48:07.3574478Z #4 transferring context: 2B done
2025-03-08T03:48:07.3574979Z #4 DONE 0.0s
2025-03-08T03:48:07.3575216Z 
2025-03-08T03:48:07.3575362Z #5 [internal] load build context
2025-03-08T03:48:07.3575864Z #5 transferring context: 1.46kB done
2025-03-08T03:48:07.3576376Z #5 DONE 0.0s
2025-03-08T03:48:07.3576622Z 
2025-03-08T03:48:07.3577291Z #6 [1/4] FROM docker.io/library/node:20-alpine@sha256:053c1d99e608fe9fa0db6821edd84276277c0a663cd181f4a3e59ee20f5f07ea
2025-03-08T03:48:07.3578463Z #6 resolve docker.io/library/node:20-alpine@sha256:053c1d99e608fe9fa0db6821edd84276277c0a663cd181f4a3e59ee20f5f07ea done
2025-03-08T03:48:07.3579291Z #6 sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870 0B / 3.64MB 0.1s
2025-03-08T03:48:07.3580365Z #6 sha256:905fb610ce71a10484abc2df972ec07b30088dabb8eedeb665f1ea50ff47b3cc 0B / 42.62MB 0.1s
2025-03-08T03:48:07.3581064Z #6 sha256:2a055f0c83be4329e887452a8868e5e83bde34eda9f7e582de5833dc9dc53446 0B / 1.26MB 0.1s
2025-03-08T03:48:07.3581766Z #6 sha256:053c1d99e608fe9fa0db6821edd84276277c0a663cd181f4a3e59ee20f5f07ea 7.67kB / 7.67kB done
2025-03-08T03:48:07.3582525Z #6 sha256:ba8312129a193a1f1a781d93afcf6e641956d6e48e3ddefa9b64cd86790ee64c 1.72kB / 1.72kB done
2025-03-08T03:48:07.3583456Z #6 sha256:62dd47071da9b5f894d190944036caf6e5fad07d32f61c15f47d8ce7c03003d2 6.18kB / 6.18kB done
2025-03-08T03:48:07.4730438Z #6 sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870 3.64MB / 3.64MB 0.1s done
2025-03-08T03:48:07.4731918Z #6 extracting sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870 0.1s done
2025-03-08T03:48:07.4733348Z #6 sha256:0416551166ae31475d009b5a4100c21041df7fb1720d2361d5138bc9144acbc9 0B / 446B 0.2s
2025-03-08T03:48:07.6565898Z #6 sha256:905fb610ce71a10484abc2df972ec07b30088dabb8eedeb665f1ea50ff47b3cc 17.83MB / 42.62MB 0.4s
2025-03-08T03:48:07.6568829Z #6 sha256:2a055f0c83be4329e887452a8868e5e83bde34eda9f7e582de5833dc9dc53446 1.26MB / 1.26MB 0.2s done
2025-03-08T03:48:07.6570179Z #6 sha256:0416551166ae31475d009b5a4100c21041df7fb1720d2361d5138bc9144acbc9 446B / 446B 0.3s done
2025-03-08T03:48:07.7567868Z #6 sha256:905fb610ce71a10484abc2df972ec07b30088dabb8eedeb665f1ea50ff47b3cc 28.31MB / 42.62MB 0.5s
2025-03-08T03:48:07.9229130Z #6 sha256:905fb610ce71a10484abc2df972ec07b30088dabb8eedeb665f1ea50ff47b3cc 39.85MB / 42.62MB 0.6s
2025-03-08T03:48:07.9231889Z #6 extracting sha256:905fb610ce71a10484abc2df972ec07b30088dabb8eedeb665f1ea50ff47b3cc
2025-03-08T03:48:08.0251886Z #6 sha256:905fb610ce71a10484abc2df972ec07b30088dabb8eedeb665f1ea50ff47b3cc 42.62MB / 42.62MB 0.7s done
2025-03-08T03:48:09.0644797Z #6 extracting sha256:905fb610ce71a10484abc2df972ec07b30088dabb8eedeb665f1ea50ff47b3cc 1.0s done
2025-03-08T03:48:09.1380447Z #6 extracting sha256:2a055f0c83be4329e887452a8868e5e83bde34eda9f7e582de5833dc9dc53446
2025-03-08T03:48:09.3341811Z #6 extracting sha256:2a055f0c83be4329e887452a8868e5e83bde34eda9f7e582de5833dc9dc53446 0.0s done
2025-03-08T03:48:09.3343070Z #6 extracting sha256:0416551166ae31475d009b5a4100c21041df7fb1720d2361d5138bc9144acbc9 done
2025-03-08T03:48:09.3343758Z #6 DONE 2.0s
2025-03-08T03:48:09.3343922Z 
2025-03-08T03:48:09.3344577Z #7 [2/4] RUN apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest
2025-03-08T03:48:09.3345510Z #7 0.131 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
2025-03-08T03:48:09.5486763Z #7 0.345 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
2025-03-08T03:48:09.9334399Z #7 0.730 (1/12) Installing brotli-libs (1.1.0-r2)
2025-03-08T03:48:10.0836305Z #7 0.741 (2/12) Installing c-ares (1.34.3-r0)
2025-03-08T03:48:10.0836866Z #7 0.745 (3/12) Installing libunistring (1.2-r0)
2025-03-08T03:48:10.0837375Z #7 0.758 (4/12) Installing libidn2 (2.3.7-r0)
2025-03-08T03:48:10.0837853Z #7 0.763 (5/12) Installing nghttp2-libs (1.64.0-r0)
2025-03-08T03:48:10.0838247Z #7 0.766 (6/12) Installing libpsl (0.21.5-r3)
2025-03-08T03:48:10.0838544Z #7 0.769 (7/12) Installing zstd-libs (1.5.6-r2)
2025-03-08T03:48:10.0838820Z #7 0.778 (8/12) Installing libcurl (8.12.1-r0)
2025-03-08T03:48:10.0839081Z #7 0.785 (9/12) Installing libexpat (2.6.4-r0)
2025-03-08T03:48:10.0839338Z #7 0.788 (10/12) Installing pcre2 (10.43-r0)
2025-03-08T03:48:10.0839590Z #7 0.796 (11/12) Installing git (2.47.2-r0)
2025-03-08T03:48:10.0839877Z #7 0.881 (12/12) Installing git-init-template (2.47.2-r0)
2025-03-08T03:48:10.3086079Z #7 0.884 Executing busybox-1.37.0-r12.trigger
2025-03-08T03:48:10.3086575Z #7 0.890 OK: 21 MiB in 29 packages
2025-03-08T03:48:10.3087002Z #7 0.955 Cloning into '/quartz'...
2025-03-08T03:48:10.9645891Z #7 1.761 npm warn config only Use `--omit=dev` to omit dev dependencies from the install.
2025-03-08T03:48:18.3687843Z #7 9.165 
2025-03-08T03:48:18.3688361Z #7 9.165 added 479 packages, and audited 480 packages in 7s
2025-03-08T03:48:18.5217408Z #7 9.166 
2025-03-08T03:48:18.5217818Z #7 9.166 177 packages are looking for funding
2025-03-08T03:48:18.5218338Z #7 9.166   run `npm fund` for details
2025-03-08T03:48:18.5218747Z #7 9.167 
2025-03-08T03:48:18.5219032Z #7 9.167 found 0 vulnerabilities
2025-03-08T03:48:18.5219392Z #7 9.168 npm notice
2025-03-08T03:48:18.5219853Z #7 9.168 npm notice New major version of npm available! 10.8.2 -> 11.2.0
2025-03-08T03:48:18.5220587Z #7 9.168 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.2.0
2025-03-08T03:48:18.5221264Z #7 9.168 npm notice To update run: npm install -g npm@11.2.0
2025-03-08T03:48:18.5221727Z #7 9.168 npm notice
2025-03-08T03:48:19.0750402Z #7 9.872 /usr/bin/env: unrecognized option: S
2025-03-08T03:48:19.2290557Z #7 9.875 BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary.
2025-03-08T03:48:19.2293009Z #7 9.875 
2025-03-08T03:48:19.2293425Z #7 9.875 Usage: env [-i0] [-u NAME]... [-] [NAME=VALUE]... [PROG ARGS]
2025-03-08T03:48:19.2293918Z #7 9.875 
2025-03-08T03:48:19.2294367Z #7 9.875 Print current environment or run PROG after setting up environment
2025-03-08T03:48:19.2294924Z #7 9.875 
2025-03-08T03:48:19.2295262Z #7 9.875 	-, -i	Start with empty environment
2025-03-08T03:48:19.2295676Z #7 9.875 	-0	NUL terminated output
2025-03-08T03:48:19.2295952Z #7 9.875 	-u NAME	Remove variable from environment
2025-03-08T03:48:20.1644315Z #7 ERROR: process "/bin/sh -c apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest" did not complete successfully: exit code: 1
2025-03-08T03:48:20.1720963Z ------
2025-03-08T03:48:20.1723461Z  > [2/4] RUN apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest:
2025-03-08T03:48:20.1724683Z 9.872 /usr/bin/env: unrecognized option: S
2025-03-08T03:48:20.1725205Z 9.875 BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary.
2025-03-08T03:48:20.1725654Z 9.875 
2025-03-08T03:48:20.1726033Z 9.875 Usage: env [-i0] [-u NAME]... [-] [NAME=VALUE]... [PROG ARGS]
2025-03-08T03:48:20.1726524Z 9.875 
2025-03-08T03:48:20.1726955Z 9.875 Print current environment or run PROG after setting up environment
2025-03-08T03:48:20.1727490Z 9.875 
2025-03-08T03:48:20.1727771Z 9.875 	-, -i	Start with empty environment
2025-03-08T03:48:20.1728186Z 9.875 	-0	NUL terminated output
2025-03-08T03:48:20.1728588Z 9.875 	-u NAME	Remove variable from environment
2025-03-08T03:48:20.1728991Z ------
2025-03-08T03:48:20.1935003Z Dockerfile:4
2025-03-08T03:48:20.1935619Z --------------------
2025-03-08T03:48:20.1935956Z    3 |     
2025-03-08T03:48:20.1936376Z    4 | >>> RUN apk add --no-cache git \
2025-03-08T03:48:20.1938308Z    5 | >>>     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz \
2025-03-08T03:48:20.1938935Z    6 | >>>     && cd /quartz \
2025-03-08T03:48:20.1939280Z    7 | >>>     && mkdir -p content \
2025-03-08T03:48:20.1939542Z    8 | >>>     && npm ci --only=production \
2025-03-08T03:48:20.1939818Z    9 | >>>     && npx quartz create -X new -l shortest
2025-03-08T03:48:20.1940079Z   10 |     
2025-03-08T03:48:20.1940241Z --------------------
2025-03-08T03:48:20.1941119Z ERROR: failed to solve: process "/bin/sh -c apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest" did not complete successfully: exit code: 1
2025-03-08T03:48:20.2010238Z ##[warning]Docker build failed with exit code 1, back off 2.009 seconds before retry.
2025-03-08T03:48:22.2110604Z ##[command]/usr/bin/docker build -t d9a3de:d252db9bf8784d7ca5d369bb083c9f7a -f "/home/runner/work/_actions/konstfish/quartz-build-action/v3/Dockerfile" "/home/runner/work/_actions/konstfish/quartz-build-action/v3"
2025-03-08T03:48:22.4877431Z #0 building with "default" instance using docker driver
2025-03-08T03:48:22.4878822Z 
2025-03-08T03:48:22.4879373Z #1 [internal] load build definition from Dockerfile
2025-03-08T03:48:22.4880180Z #1 transferring dockerfile: 404B done
2025-03-08T03:48:22.4880836Z #1 DONE 0.0s
2025-03-08T03:48:22.4881029Z 
2025-03-08T03:48:22.4881288Z #2 [internal] load metadata for docker.io/library/node:20-alpine
2025-03-08T03:48:22.4881938Z #2 DONE 0.1s
2025-03-08T03:48:22.6179633Z 
2025-03-08T03:48:22.6180158Z #3 [internal] load .dockerignore
2025-03-08T03:48:22.6180595Z #3 transferring context: 2B done
2025-03-08T03:48:22.6180925Z #3 DONE 0.0s
2025-03-08T03:48:22.6181283Z 
2025-03-08T03:48:22.6181854Z #4 [1/4] FROM docker.io/library/node:20-alpine@sha256:053c1d99e608fe9fa0db6821edd84276277c0a663cd181f4a3e59ee20f5f07ea
2025-03-08T03:48:22.6182661Z #4 CACHED
2025-03-08T03:48:22.6182830Z 
2025-03-08T03:48:22.6183180Z #5 [internal] load build context
2025-03-08T03:48:22.6183587Z #5 transferring context: 35B done
2025-03-08T03:48:22.6183951Z #5 DONE 0.0s
2025-03-08T03:48:22.6184117Z 
2025-03-08T03:48:22.6185084Z #6 [2/4] RUN apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest
2025-03-08T03:48:22.6186548Z #6 0.125 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
2025-03-08T03:48:22.8338968Z #6 0.191 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
2025-03-08T03:48:23.0804474Z #6 0.588 (1/12) Installing brotli-libs (1.1.0-r2)
2025-03-08T03:48:23.2036104Z #6 0.598 (2/12) Installing c-ares (1.34.3-r0)
2025-03-08T03:48:23.2036649Z #6 0.602 (3/12) Installing libunistring (1.2-r0)
2025-03-08T03:48:23.2037283Z #6 0.613 (4/12) Installing libidn2 (2.3.7-r0)
2025-03-08T03:48:23.2037586Z #6 0.617 (5/12) Installing nghttp2-libs (1.64.0-r0)
2025-03-08T03:48:23.2037885Z #6 0.620 (6/12) Installing libpsl (0.21.5-r3)
2025-03-08T03:48:23.2038156Z #6 0.623 (7/12) Installing zstd-libs (1.5.6-r2)
2025-03-08T03:48:23.2038416Z #6 0.631 (8/12) Installing libcurl (8.12.1-r0)
2025-03-08T03:48:23.2038666Z #6 0.638 (9/12) Installing libexpat (2.6.4-r0)
2025-03-08T03:48:23.2038927Z #6 0.641 (10/12) Installing pcre2 (10.43-r0)
2025-03-08T03:48:23.2039181Z #6 0.648 (11/12) Installing git (2.47.2-r0)
2025-03-08T03:48:23.2039455Z #6 0.711 (12/12) Installing git-init-template (2.47.2-r0)
2025-03-08T03:48:23.4274621Z #6 0.714 Executing busybox-1.37.0-r12.trigger
2025-03-08T03:48:23.4275244Z #6 0.719 OK: 21 MiB in 29 packages
2025-03-08T03:48:23.4275711Z #6 0.784 Cloning into '/quartz'...
2025-03-08T03:48:23.9695970Z #6 1.477 npm warn config only Use `--omit=dev` to omit dev dependencies from the install.
2025-03-08T03:48:31.4978929Z #6 9.005 
2025-03-08T03:48:31.4979402Z #6 9.005 added 479 packages, and audited 480 packages in 8s
2025-03-08T03:48:31.6508084Z #6 9.005 
2025-03-08T03:48:31.6508356Z #6 9.005 177 packages are looking for funding
2025-03-08T03:48:31.6508649Z #6 9.005   run `npm fund` for details
2025-03-08T03:48:31.6508960Z #6 9.006 
2025-03-08T03:48:31.6509222Z #6 9.006 found 0 vulnerabilities
2025-03-08T03:48:31.6509437Z #6 9.008 npm notice
2025-03-08T03:48:31.6509712Z #6 9.008 npm notice New major version of npm available! 10.8.2 -> 11.2.0
2025-03-08T03:48:31.6510312Z #6 9.008 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.2.0
2025-03-08T03:48:31.6511049Z #6 9.008 npm notice To update run: npm install -g npm@11.2.0
2025-03-08T03:48:31.6511547Z #6 9.008 npm notice
2025-03-08T03:48:32.2335335Z #6 9.741 /usr/bin/env: unrecognized option: S
2025-03-08T03:48:32.2930274Z #6 9.744 BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary.
2025-03-08T03:48:32.2937482Z #6 9.744 
2025-03-08T03:48:32.2937970Z #6 9.744 Usage: env [-i0] [-u NAME]... [-] [NAME=VALUE]... [PROG ARGS]
2025-03-08T03:48:32.2938546Z #6 9.744 
2025-03-08T03:48:32.2939016Z #6 9.744 Print current environment or run PROG after setting up environment
2025-03-08T03:48:32.2939715Z #6 9.744 
2025-03-08T03:48:32.2940038Z #6 9.744 	-, -i	Start with empty environment
2025-03-08T03:48:32.2940476Z #6 9.744 	-0	NUL terminated output
2025-03-08T03:48:32.2940909Z #6 9.744 	-u NAME	Remove variable from environment
2025-03-08T03:48:32.2942533Z #6 ERROR: process "/bin/sh -c apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest" did not complete successfully: exit code: 1
2025-03-08T03:48:32.2944298Z ------
2025-03-08T03:48:32.2945381Z  > [2/4] RUN apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest:
2025-03-08T03:48:32.2946673Z 9.741 /usr/bin/env: unrecognized option: S
2025-03-08T03:48:32.2947196Z 9.744 BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary.
2025-03-08T03:48:32.2947674Z 9.744 
2025-03-08T03:48:32.2949081Z 9.744 Usage: env [-i0] [-u NAME]... [-] [NAME=VALUE]... [PROG ARGS]
2025-03-08T03:48:32.2949587Z 9.744 
2025-03-08T03:48:32.2950050Z 9.744 Print current environment or run PROG after setting up environment
2025-03-08T03:48:32.2950628Z 9.744 
2025-03-08T03:48:32.2950904Z 9.744 	-, -i	Start with empty environment
2025-03-08T03:48:32.2951328Z 9.744 	-0	NUL terminated output
2025-03-08T03:48:32.2951744Z 9.744 	-u NAME	Remove variable from environment
2025-03-08T03:48:32.2952163Z ------
2025-03-08T03:48:32.2952417Z Dockerfile:4
2025-03-08T03:48:32.2952680Z --------------------
2025-03-08T03:48:32.2953151Z    3 |     
2025-03-08T03:48:32.2953431Z    4 | >>> RUN apk add --no-cache git \
2025-03-08T03:48:32.2954292Z    5 | >>>     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz \
2025-03-08T03:48:32.2954999Z    6 | >>>     && cd /quartz \
2025-03-08T03:48:32.2955354Z    7 | >>>     && mkdir -p content \
2025-03-08T03:48:32.2955772Z    8 | >>>     && npm ci --only=production \
2025-03-08T03:48:32.2956220Z    9 | >>>     && npx quartz create -X new -l shortest
2025-03-08T03:48:32.2956644Z   10 |     
2025-03-08T03:48:32.2957046Z --------------------
2025-03-08T03:48:32.2958640Z ERROR: failed to solve: process "/bin/sh -c apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest" did not complete successfully: exit code: 1
2025-03-08T03:48:32.3071925Z ##[warning]Docker build failed with exit code 1, back off 6.568 seconds before retry.
2025-03-08T03:48:38.8755497Z ##[command]/usr/bin/docker build -t d9a3de:d252db9bf8784d7ca5d369bb083c9f7a -f "/home/runner/work/_actions/konstfish/quartz-build-action/v3/Dockerfile" "/home/runner/work/_actions/konstfish/quartz-build-action/v3"
2025-03-08T03:48:38.9998273Z #0 building with "default" instance using docker driver
2025-03-08T03:48:38.9998934Z 
2025-03-08T03:48:38.9999140Z #1 [internal] load build definition from Dockerfile
2025-03-08T03:48:39.1558402Z #1 transferring dockerfile: 404B done
2025-03-08T03:48:39.1558981Z #1 DONE 0.0s
2025-03-08T03:48:39.1559105Z 
2025-03-08T03:48:39.1559272Z #2 [internal] load metadata for docker.io/library/node:20-alpine
2025-03-08T03:48:39.2764331Z #2 DONE 0.3s
2025-03-08T03:48:39.4100098Z 
2025-03-08T03:48:39.4100505Z #3 [internal] load .dockerignore
2025-03-08T03:48:39.4100925Z #3 transferring context: 2B done
2025-03-08T03:48:39.4101381Z #3 DONE 0.0s
2025-03-08T03:48:39.4101544Z 
2025-03-08T03:48:39.4102078Z #4 [1/4] FROM docker.io/library/node:20-alpine@sha256:053c1d99e608fe9fa0db6821edd84276277c0a663cd181f4a3e59ee20f5f07ea
2025-03-08T03:48:39.4103533Z #4 CACHED
2025-03-08T03:48:39.4103716Z 
2025-03-08T03:48:39.4103865Z #5 [internal] load build context
2025-03-08T03:48:39.4104250Z #5 transferring context: 35B done
2025-03-08T03:48:39.4104686Z #5 DONE 0.0s
2025-03-08T03:48:39.4104844Z 
2025-03-08T03:48:39.4105789Z #6 [2/4] RUN apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest
2025-03-08T03:48:39.4107247Z #6 0.127 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/main/x86_64/APKINDEX.tar.gz
2025-03-08T03:48:39.6296839Z #6 0.197 fetch https://dl-cdn.alpinelinux.org/alpine/v3.21/community/x86_64/APKINDEX.tar.gz
2025-03-08T03:48:39.7240345Z #6 0.441 (1/12) Installing brotli-libs (1.1.0-r2)
2025-03-08T03:48:39.8409889Z #6 0.451 (2/12) Installing c-ares (1.34.3-r0)
2025-03-08T03:48:39.8410423Z #6 0.454 (3/12) Installing libunistring (1.2-r0)
2025-03-08T03:48:39.8410752Z #6 0.465 (4/12) Installing libidn2 (2.3.7-r0)
2025-03-08T03:48:39.8411059Z #6 0.469 (5/12) Installing nghttp2-libs (1.64.0-r0)
2025-03-08T03:48:39.8411345Z #6 0.472 (6/12) Installing libpsl (0.21.5-r3)
2025-03-08T03:48:39.8411603Z #6 0.474 (7/12) Installing zstd-libs (1.5.6-r2)
2025-03-08T03:48:39.8411866Z #6 0.481 (8/12) Installing libcurl (8.12.1-r0)
2025-03-08T03:48:39.8412109Z #6 0.487 (9/12) Installing libexpat (2.6.4-r0)
2025-03-08T03:48:39.8412371Z #6 0.490 (10/12) Installing pcre2 (10.43-r0)
2025-03-08T03:48:39.8412628Z #6 0.497 (11/12) Installing git (2.47.2-r0)
2025-03-08T03:48:39.8413104Z #6 0.559 (12/12) Installing git-init-template (2.47.2-r0)
2025-03-08T03:48:40.0645047Z #6 0.562 Executing busybox-1.37.0-r12.trigger
2025-03-08T03:48:40.0645562Z #6 0.567 OK: 21 MiB in 29 packages
2025-03-08T03:48:40.0645897Z #6 0.632 Cloning into '/quartz'...
2025-03-08T03:48:40.6591575Z #6 1.377 npm warn config only Use `--omit=dev` to omit dev dependencies from the install.
2025-03-08T03:48:48.1683812Z #6 8.886 
2025-03-08T03:48:48.1684615Z #6 8.886 added 479 packages, and audited 480 packages in 8s
2025-03-08T03:48:48.3213026Z #6 8.886 
2025-03-08T03:48:48.3213432Z #6 8.886 177 packages are looking for funding
2025-03-08T03:48:48.3213924Z #6 8.886   run `npm fund` for details
2025-03-08T03:48:48.3214351Z #6 8.887 
2025-03-08T03:48:48.3214617Z #6 8.887 found 0 vulnerabilities
2025-03-08T03:48:48.3215029Z #6 8.888 npm notice
2025-03-08T03:48:48.3215502Z #6 8.888 npm notice New major version of npm available! 10.8.2 -> 11.2.0
2025-03-08T03:48:48.3216292Z #6 8.888 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.2.0
2025-03-08T03:48:48.3217000Z #6 8.888 npm notice To update run: npm install -g npm@11.2.0
2025-03-08T03:48:48.3217518Z #6 8.888 npm notice
2025-03-08T03:48:48.8435292Z #6 9.561 /usr/bin/env: unrecognized option: S
2025-03-08T03:48:48.9977723Z #6 9.565 BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary.
2025-03-08T03:48:48.9978100Z #6 9.565 
2025-03-08T03:48:48.9978382Z #6 9.565 Usage: env [-i0] [-u NAME]... [-] [NAME=VALUE]... [PROG ARGS]
2025-03-08T03:48:48.9978711Z #6 9.565 
2025-03-08T03:48:48.9979005Z #6 9.565 Print current environment or run PROG after setting up environment
2025-03-08T03:48:48.9979358Z #6 9.565 
2025-03-08T03:48:48.9979560Z #6 9.565 	-, -i	Start with empty environment
2025-03-08T03:48:48.9979822Z #6 9.565 	-0	NUL terminated output
2025-03-08T03:48:48.9980092Z #6 9.565 	-u NAME	Remove variable from environment
2025-03-08T03:48:49.8531018Z #6 ERROR: process "/bin/sh -c apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest" did not complete successfully: exit code: 1
2025-03-08T03:48:49.8591600Z ------
2025-03-08T03:48:49.8593078Z  > [2/4] RUN apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest:
2025-03-08T03:48:49.8594878Z 9.561 /usr/bin/env: unrecognized option: S
2025-03-08T03:48:49.8595436Z 9.565 BusyBox v1.37.0 (2025-01-17 18:12:01 UTC) multi-call binary.
2025-03-08T03:48:49.8595937Z 9.565 
2025-03-08T03:48:49.8596321Z 9.565 Usage: env [-i0] [-u NAME]... [-] [NAME=VALUE]... [PROG ARGS]
2025-03-08T03:48:49.8596802Z 9.565 
2025-03-08T03:48:49.8597257Z 9.565 Print current environment or run PROG after setting up environment
2025-03-08T03:48:49.8597811Z 9.565 
2025-03-08T03:48:49.8598116Z 9.565 	-, -i	Start with empty environment
2025-03-08T03:48:49.8598542Z 9.565 	-0	NUL terminated output
2025-03-08T03:48:49.8598960Z 9.565 	-u NAME	Remove variable from environment
2025-03-08T03:48:49.8599380Z ------
2025-03-08T03:48:49.8605853Z Dockerfile:4
2025-03-08T03:48:49.8606114Z --------------------
2025-03-08T03:48:49.8606404Z    3 |     
2025-03-08T03:48:49.8606692Z    4 | >>> RUN apk add --no-cache git \
2025-03-08T03:48:49.8607248Z    5 | >>>     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz \
2025-03-08T03:48:49.8607798Z    6 | >>>     && cd /quartz \
2025-03-08T03:48:49.8608136Z    7 | >>>     && mkdir -p content \
2025-03-08T03:48:49.8608526Z    8 | >>>     && npm ci --only=production \
2025-03-08T03:48:49.8608957Z    9 | >>>     && npx quartz create -X new -l shortest
2025-03-08T03:48:49.8609341Z   10 |     
2025-03-08T03:48:49.8609591Z --------------------
2025-03-08T03:48:49.8611007Z ERROR: failed to solve: process "/bin/sh -c apk add --no-cache git     && git clone --depth 1 https://github.com/jackyzha0/quartz.git /quartz     && cd /quartz     && mkdir -p content     && npm ci --only=production     && npx quartz create -X new -l shortest" did not complete successfully: exit code: 1
2025-03-08T03:48:49.8644485Z ##[endgroup]
2025-03-08T03:48:49.8729462Z ##[error]Docker build failed with exit code 1
2025-03-08T03:48:49.8815303Z Cleaning up orphan processes
```