### PR TITLE
feat(action): custom css support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
           quartz_layout: example_projects/custom_theme/config/quartz.layout.ts
           quartz_icon: example_projects/custom_theme/images/icon_mod.png
           quartz_banner: example_projects/custom_theme/images/og-image_mod.png
+          custom_css: example_projects/custom_theme/config/custom.scss
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
           quartz_layout: example_projects/custom_theme/config/quartz.layout.ts
           quartz_icon: example_projects/custom_theme/images/icon_mod.png
           quartz_banner: example_projects/custom_theme/images/og-image_mod.png
-          custom_css: example_projects/custom_theme/config/custom.scss
+          quartz_custom_css: example_projects/custom_theme/config/custom.scss
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Custom configuration & layout files can be included like this:
     # quartz static content
     quartz_icon:   .github/quartz/favicon.png
     quartz_banner: .github/quartz/og_image.png
+    # custom css
+    custom_css: .github/quartz/custom.scss
 ```
 
 A productive example of a workflow using this action can be found [here](https://github.com/konstfish/shoal/blob/main/.github/workflows/publish_blog.yaml).
@@ -74,3 +76,4 @@ A productive example of a workflow using this action can be found [here](https:/
 | `quartz_layout` | ``        | Path to custom Quartz layout file       |
 | `quartz_icon`   | ``        | Path to custom Quartz Page icon (png)   |
 | `quartz_banner` | ``        | Path to custom Quartz Page banner (png) |
+| `custom_css`    | ``        | Path to custom Quartz Page css |

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Custom configuration & layout files can be included like this:
     quartz_icon:   .github/quartz/favicon.png
     quartz_banner: .github/quartz/og_image.png
     # custom css
-    custom_css: .github/quartz/custom.scss
+    quartz_custom_css: .github/quartz/custom.scss
 ```
 
 A productive example of a workflow using this action can be found [here](https://github.com/konstfish/shoal/blob/main/.github/workflows/publish_blog.yaml).
@@ -76,4 +76,4 @@ A productive example of a workflow using this action can be found [here](https:/
 | `quartz_layout` | ``        | Path to custom Quartz layout file       |
 | `quartz_icon`   | ``        | Path to custom Quartz Page icon (png)   |
 | `quartz_banner` | ``        | Path to custom Quartz Page banner (png) |
-| `custom_css`    | ``        | Path to custom Quartz Page css |
+| `quartz_custom_css`    | ``        | Path to custom Quartz Page css |

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,9 @@ inputs:
   quartz_banner:
     description: 'Path to custom Quartz Page banner (png)'
     required: false
+  custom_css:
+    description: 'Path to custom Quartz Page css'
+    required: false
 
 runs:
   using: 'docker'

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
   quartz_banner:
     description: 'Path to custom Quartz Page banner (png)'
     required: false
-  custom_css:
+  quartz_custom_css:
     description: 'Path to custom Quartz Page css'
     required: false
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,12 @@ if [ -n "$INPUT_QUARTZ_BANNER" ]; then
     cp ${GITHUB_WORKSPACE}/$INPUT_QUARTZ_BANNER /quartz/quartz/static/og-image.png
 fi
 
+# custom.css
+if [ -n "$INPUT_CUSTOM_CSS" ]; then
+    echo "Copying custom css (${GITHUB_WORKSPACE}/$INPUT_CUSTOM_CSS -> $(pwd)/styles/custom.scss)"
+    cp ${GITHUB_WORKSPACE}/$INPUT_CUSTOM_CSS /quartz/quartz/styles/custom.scss
+fi
+
 # content
 mv $SOURCE_DIRECTORY/* /quartz/content/
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,9 +35,9 @@ if [ -n "$INPUT_QUARTZ_BANNER" ]; then
 fi
 
 # custom.css
-if [ -n "$INPUT_CUSTOM_CSS" ]; then
-    echo "Copying custom css (${GITHUB_WORKSPACE}/$INPUT_CUSTOM_CSS -> $(pwd)/styles/custom.scss)"
-    cp ${GITHUB_WORKSPACE}/$INPUT_CUSTOM_CSS /quartz/quartz/styles/custom.scss
+if [ -n "$INPUT_QUARTZ_CUSTOM_CSS" ]; then
+    echo "Copying custom css (${GITHUB_WORKSPACE}/$INPUT_QUARTZ_CUSTOM_CSS -> $(pwd)/styles/custom.scss)"
+    cp ${GITHUB_WORKSPACE}/$INPUT_QUARTZ_CUSTOM_CSS /quartz/quartz/styles/custom.scss
 fi
 
 # content

--- a/example_projects/custom_theme/config/custom.scss
+++ b/example_projects/custom_theme/config/custom.scss
@@ -1,0 +1,25 @@
+@use "./base.scss";
+
+// put your custom CSS here!
+
+/**
+ * iframe custom css
+ **/
+ iframe[src*="youtu"] {
+  width: 100%;
+  height: 40vh;
+  border-radius: 0.5rem !important;
+}
+
+iframe[src*="bilibili"] {
+  width: 100%;
+  height: 40vh;
+  border-radius: 0.5rem !important;
+
+}
+
+.iframe-radius, .references-blocks-item {
+  --tw-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -1px rgba(0, 0, 0, 0.06) !important;
+  border-radius: 0.5rem !important;
+  box-shadow: var(--tw-shadow) !important;
+}

--- a/example_projects/custom_theme/content/index.md
+++ b/example_projects/custom_theme/content/index.md
@@ -1,3 +1,6 @@
 This is themed
 
 See [[test]]
+
+<iframe src="https://www.youtube.com/embed/DgqAAE9Aagc" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<center>via: <a href='https://www.youtube.com/watch?v=DgqAAE9Aagc' target='_blank' class='external-link'>https://www.youtube.com/watch?v=DgqAAE9Aagc</a></center>

--- a/example_projects/default/content/index.md
+++ b/example_projects/default/content/index.md
@@ -1,1 +1,4 @@
 See [[test]]
+
+<iframe src="https://www.youtube.com/embed/DgqAAE9Aagc" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<center>via: <a href='https://www.youtube.com/watch?v=DgqAAE9Aagc' target='_blank' class='external-link'>https://www.youtube.com/watch?v=DgqAAE9Aagc</a></center>


### PR DESCRIPTION
This PR add a params for github action, `quartz_custom_css`, which means you could bring your obsidian custom.css to quzrtz publish. 

## How it works

The [upstream](https://github.com/jackyzha0/quartz/blob/v4/quartz/styles/custom.scss) support custom css in `quartz/styles/custom.scss`. 

> You can see the base style sheet in `quartz/styles/base.scss` and write your own in `quartz/styles/custom.scss`.
> https://quartz.jzhao.xyz/layout


I add some basic iframe styles. And it looks good to me. 

## Origin style

<img width="1869" alt="图片" src="https://github.com/user-attachments/assets/f5106056-d857-4ef0-b27f-354156912573" />

## Custom style

<img width="1559" alt="图片" src="https://github.com/user-attachments/assets/5231c3aa-6330-4318-b7bf-42bfe72c9d5e" />

Hope this helpful for you as well.

