### PR TITLE
fix(verison): npm version required node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG NODE_VERSION=20
+ARG NODE_VERSION=22
 FROM node:${NODE_VERSION}-alpine
 
 RUN apk add --no-cache git coreutils \


### PR DESCRIPTION
This PR fix specific node version when building docker, which change node verison from 20 to 22. Since the error log building with old version is as follows:

```
2025-06-02T05:14:13.0232565Z 0.978 OK: 24 MiB in 38 packages
2025-06-02T05:14:13.0232950Z 1.046 Cloning into '/quartz'...
2025-06-02T05:14:13.0233511Z 1.730 npm warn config only Use `--omit=dev` to omit dev dependencies from the install.
2025-06-02T05:14:13.0234127Z 2.270 npm error code EBADENGINE
2025-06-02T05:14:13.0234516Z 2.270 npm error engine Unsupported engine
2025-06-02T05:14:13.0235178Z 2.271 npm error engine Not compatible with your version of node/npm: @jackyzha0/quartz@4.5.1
2025-06-02T05:14:13.0236104Z 2.271 npm error notsup Not compatible with your version of node/npm: @jackyzha0/quartz@4.5.1
2025-06-02T05:14:13.0236882Z 2.271 npm error notsup Required: {"npm":">=10.9.2","node":">=22"}
2025-06-02T05:14:13.0237532Z 2.271 npm error notsup Actual:   {"npm":"10.8.2","node":"v20.19.2"}
2025-06-02T05:14:13.0238370Z 2.272 npm error A complete log of this run can be found in: /root/.npm/_logs/2025-06-02T05_14_12_382Z-debug-0.log
```

via: https://github.com/bGZo/quartz-build-action/actions/runs/15384456235

## Does it works?

I've been test on my action via: https://github.com/bGZo/quartz-build-action/actions/runs/15384479020

Wish this could help
